### PR TITLE
Allow treq persistent request option to be configurable

### DIFF
--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -9,7 +9,7 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 
 import treq
 
-from confmodel.fields import ConfigText
+from confmodel.fields import ConfigText, ConfigBool
 
 from go_metrics.metrics.base import Metrics, MetricsBackend, MetricsBackendError
 
@@ -73,7 +73,7 @@ class GraphiteMetrics(Metrics):
         }
         params.update(kw)
         url = self._build_render_url(params)
-        resp = yield treq.get(url, persistent=False)
+        resp = yield treq.get(url, persistent=self.backend.config.persistent)
 
         if is_error(resp):
             raise MetricsBackendError(
@@ -85,8 +85,13 @@ class GraphiteMetrics(Metrics):
 
 class GraphiteBackendConfig(MetricsBackend.config_class):
     graphite_url = ConfigText(
-        "Url for graphite web app to query",
+        "Url for the graphite web server to query",
         default='http://127.0.0.1:8080')
+
+    persistent = ConfigBool(
+        "Flag given to treq telling it whether to maintain a single connection ",
+        "for the requests made to graphite's web app",
+        default=True)
 
 
 class GraphiteBackend(MetricsBackend):

--- a/go_metrics/metrics/tests/test_graphite.py
+++ b/go_metrics/metrics/tests/test_graphite.py
@@ -18,6 +18,10 @@ class TestGraphiteMetrics(TestCase):
         self.addCleanup(graphite.stop)
         returnValue(graphite)
 
+    def mk_backend(self, **kw):
+        kw.setdefault('persistent', False)
+        return GraphiteBackend(kw)
+
     @inlineCallbacks
     def test_get_request(self):
         reqs = []
@@ -27,7 +31,7 @@ class TestGraphiteMetrics(TestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = GraphiteBackend({'graphite_url': graphite.url})
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(**{
@@ -62,7 +66,7 @@ class TestGraphiteMetrics(TestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = GraphiteBackend({'graphite_url': graphite.url})
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(**{
@@ -101,7 +105,7 @@ class TestGraphiteMetrics(TestCase):
             }])
 
         graphite = yield self.mk_graphite(handler)
-        backend = GraphiteBackend({'graphite_url': graphite.url})
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         data = yield metrics.get(**{
@@ -137,7 +141,7 @@ class TestGraphiteMetrics(TestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = GraphiteBackend({'graphite_url': graphite.url})
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(**{
@@ -158,7 +162,7 @@ class TestGraphiteMetrics(TestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = GraphiteBackend({'graphite_url': graphite.url})
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(m=['stores.a.b.last'])
@@ -180,7 +184,7 @@ class TestGraphiteMetrics(TestCase):
             return ':('
 
         graphite = yield self.mk_graphite(handler)
-        backend = GraphiteBackend({'graphite_url': graphite.url})
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         try:


### PR DESCRIPTION
At the moment, we need this so that we can turn it off in tests to avoid unclean reactors after test runs.
