### PR TITLE
Don't include graphite error responses in responses to client

### DIFF
--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -113,8 +113,7 @@ class GraphiteMetrics(Metrics):
 
         if is_error(resp):
             raise MetricsBackendError(
-                "Got error response for request to graphite: "
-                "(%s) %s" % (resp.code, (yield resp.content())))
+                "Got error response interacting with metrics backend")
 
         null_parser = null_parsers[params['nulls']]
         returnValue(self._parse_response((yield resp.json()), null_parser))

--- a/go_metrics/metrics/tests/test_graphite.py
+++ b/go_metrics/metrics/tests/test_graphite.py
@@ -190,7 +190,7 @@ class TestGraphiteMetrics(TestCase):
             yield metrics.get()
         except MetricsBackendError, e:
             self.assertEqual(str(e),
-                "Got error response for request to graphite: (400) :(")
+                "Got error response interacting with metrics backend")
         else:
             self.fail("Expected an error")
 


### PR DESCRIPTION
At the moment we are accidentally giving the graphite responses to the client.
