### PR TITLE
Reject requests for large amounts of data

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -146,13 +146,23 @@ API Methods
         :ref:`metric-types` for an overview of the metric name formats.
 
     :query from:
-        The beginning time period to retrieve values from. Can be in any form
-        accepted by graphite. See graphite's `from and until`_ documentation.
+        The beginning time period to retrieve values from. Accepts a subset of
+        the forms accepted by graphite. Any purely relative time (such as
+        ``-3days`` or ``yesterday``) is allowed, but absolute timestamps must
+        be in the form ``HH:MM_YYYYMMDD`` or ``YYYYMMDD``. Unix timestamp
+        values (integer only) are also accepted. Mixing absolute and relative
+        times is not allowed. See graphite's `from and until`_ documentation
+        for reference, but bear these limitations in mind when reading it.
         Defaults to 24 hours ago.
 
     :query until:
-        The ending time period to retrieve values until. Can be in any
-        form accepted by graphite. See graphite's `from and until`_ documentation.
+        The ending time period to retrieve values from. Accepts a subset of
+        the forms accepted by graphite. Any purely relative time (such as
+        ``-3days`` or ``yesterday``) is allowed, but absolute timestamps must
+        be in the form ``HH:MM_YYYYMMDD`` or ``YYYYMMDD``. Unix timestamp
+        values (integer only) are also accepted. Mixing absolute and relative
+        times is not allowed. See graphite's `from and until`_ documentation
+        for reference, but bear these limitations in mind when reading it.
         Defaults to the current time.
 
     :query interval:

--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -2,6 +2,7 @@
 Graphite backend for the metrics api.
 """
 
+from datetime import datetime
 from urllib import urlencode
 from urlparse import urljoin
 
@@ -10,10 +11,12 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 import treq
 
 from confmodel.errors import ConfigError
-from confmodel.fields import ConfigText, ConfigBool
+from confmodel.fields import ConfigText, ConfigBool, ConfigInt
 
 from go_metrics.metrics.base import (
     Metrics, MetricsBackend, MetricsBackendError, BadMetricsQueryError)
+from go_metrics.metrics.graphite_time_parser import (
+    interval_to_seconds, parse_time)
 
 
 def agg_from_name(name):
@@ -89,6 +92,18 @@ class GraphiteMetrics(Metrics):
         else:
             return None
 
+    def _predict_data_size(self, start, end, interval):
+        """
+        Use the start and end times and interval size to predict the number of
+        data points being requested.
+        """
+        now = datetime.utcnow()
+        start_dt = parse_time(start, now)
+        end_dt = parse_time(end, now)
+        interval_secs = interval_to_seconds(interval)
+        period = end_dt - start_dt
+        return (period.seconds + 86400 * period.days) / interval_secs
+
     @inlineCallbacks
     def get(self, **kw):
         params = {
@@ -100,6 +115,14 @@ class GraphiteMetrics(Metrics):
             'align_to_from': 'false',
         }
         params.update(kw)
+
+        predicted_size = self._predict_data_size(
+            params['from'], params['until'], params['interval'])
+        max_response_size = self.backend.config.max_response_size
+        if predicted_size > max_response_size:
+            raise BadMetricsQueryError(
+                "%s data points requested, maximum allowed is %s" % (
+                    predicted_size, max_response_size))
 
         if params['nulls'] not in null_parsers:
             raise BadMetricsQueryError(
@@ -126,16 +149,22 @@ class GraphiteBackendConfig(MetricsBackend.config_class):
 
     persistent = ConfigBool(
         ("Flag given to treq telling it whether to maintain a single "
-         "connection for the requests made to graphite's web app"),
+         "connection for the requests made to graphite's web app."),
         default=True)
 
     username = ConfigText(
-        "Basic auth username for authenticating requests to graphite",
+        "Basic auth username for authenticating requests to graphite.",
         required=False)
 
     password = ConfigText(
-        "Basic auth password for authenticating requests to graphite",
+        "Basic auth password for authenticating requests to graphite.",
         required=False)
+
+    max_response_size = ConfigInt(
+        ("Maximum number of data points to return. If a request specifies a "
+         "time range and interval that contains more data than this, it is "
+         "rejected."),
+        default=10000)
 
     def post_validate(self):
         auth = (self.username, self.password)

--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -57,9 +57,6 @@ class GraphiteMetrics(Metrics):
     def _build_render_url(self, params):
         metrics = params['m']
 
-        if (isinstance(metrics, basestring)):
-            metrics = [metrics]
-
         targets = [
             self._build_metric_name(
                 name, params['interval'], params['align_to_from'])
@@ -115,8 +112,12 @@ class GraphiteMetrics(Metrics):
         }
         params.update(kw)
 
+        if (isinstance(params['m'], basestring)):
+            params['m'] = [params['m']]
+
         predicted_size = self._predict_data_size(
             params['from'], params['until'], params['interval'])
+        predicted_size *= max(1, len(params['m']))
         max_response_size = self.backend.config.max_response_size
         if predicted_size > max_response_size:
             raise BadMetricsQueryError(

--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -98,10 +98,9 @@ class GraphiteMetrics(Metrics):
         data points being requested.
         """
         now = datetime.utcnow()
-        start_dt = parse_time(start, now)
-        end_dt = parse_time(end, now)
+        # "end" can be earlier than "start".
+        period = abs(parse_time(end, now) - parse_time(start, now))
         interval_secs = interval_to_seconds(interval)
-        period = end_dt - start_dt
         return (period.seconds + 86400 * period.days) / interval_secs
 
     @inlineCallbacks

--- a/go_metrics/metrics/graphite_time_parser.py
+++ b/go_metrics/metrics/graphite_time_parser.py
@@ -1,0 +1,49 @@
+"""
+Time period and interval parameter parsers for Graphite backend.
+"""
+
+from datetime import timedelta
+import re
+
+
+class TimeParserValueError(ValueError):
+    """
+    A value could not be parsed.
+    """
+
+
+INTERVAL_RE = re.compile(r'(?P<count>\d+)(?P<unit>.+)')
+
+UNIT_VALUES = {}
+UNIT_VALUES["seconds"] = UNIT_VALUES["s"] = 1
+UNIT_VALUES["minutes"] = UNIT_VALUES["min"] = 60
+UNIT_VALUES["hours"] = UNIT_VALUES["h"] = 3600
+UNIT_VALUES["days"] = UNIT_VALUES["d"] = 24 * 3600
+UNIT_VALUES["weeks"] = UNIT_VALUES["w"] = 7 * 24 * 3600
+UNIT_VALUES["months"] = UNIT_VALUES["mon"] = 30 * 24 * 3600
+UNIT_VALUES["years"] = UNIT_VALUES["y"] = 365 * 24 * 3600
+
+
+def interval_to_seconds(interval_str):
+    parts = INTERVAL_RE.match(interval_str)
+    if parts is None:
+        raise TimeParserValueError(
+            "Invalid interval string: %r" % (interval_str,))
+    count = int(parts.groupdict()["count"])
+    unit = parts.groupdict()["unit"]
+    unit_multiplier = UNIT_VALUES.get(unit)
+    if unit_multiplier is None:
+        raise TimeParserValueError(
+            "Invalid interval string: %r" % (interval_str,))
+    return count * unit_multiplier
+
+
+def parse_absolute_time(time_str):
+    raise NotImplementedError("Absolute time specifiers not supported.")
+
+
+def parse_time(time_str, now):
+    if time_str.startswith("-"):
+        interval = interval_to_seconds(time_str[1:])
+        return now - timedelta(seconds=interval)
+    return parse_absolute_time(time_str)

--- a/go_metrics/metrics/graphite_time_parser.py
+++ b/go_metrics/metrics/graphite_time_parser.py
@@ -71,6 +71,12 @@ def parse_time(time_str, now):
           variety of formats. Currently, only relative time specifiers are
           supported.
     """
+    if time_str in ["now", "today"]:
+        return now
+    if time_str == "yesterday":
+        return now - timedelta(days=1)
+    if time_str == "tomorrow":
+        return now + timedelta(days=1)
     if time_str.startswith("-"):
         interval = interval_to_seconds(time_str[1:])
         return now - timedelta(seconds=interval)

--- a/go_metrics/metrics/graphite_time_parser.py
+++ b/go_metrics/metrics/graphite_time_parser.py
@@ -15,16 +15,30 @@ class TimeParserValueError(ValueError):
 INTERVAL_RE = re.compile(r'(?P<count>\d+)(?P<unit>.+)')
 
 UNIT_VALUES = {}
-UNIT_VALUES["seconds"] = UNIT_VALUES["s"] = 1
-UNIT_VALUES["minutes"] = UNIT_VALUES["min"] = 60
-UNIT_VALUES["hours"] = UNIT_VALUES["h"] = 3600
-UNIT_VALUES["days"] = UNIT_VALUES["d"] = 24 * 3600
-UNIT_VALUES["weeks"] = UNIT_VALUES["w"] = 7 * 24 * 3600
-UNIT_VALUES["months"] = UNIT_VALUES["mon"] = 30 * 24 * 3600
-UNIT_VALUES["years"] = UNIT_VALUES["y"] = 365 * 24 * 3600
+
+
+def _set_unit_value(value, *names):
+    for name in names:
+        UNIT_VALUES[name] = value
+
+
+_set_unit_value(1, "s", "second", "seconds")
+_set_unit_value(60, "min", "minute", "minutes")
+_set_unit_value(3600, "h", "hour", "hours")
+_set_unit_value(86400, "d", "day", "days")
+_set_unit_value(7 * 86400, "w", "week", "weeks")
+_set_unit_value(30 * 86400, "mon", "month", "months")
+_set_unit_value(365 * 86400, "y", "year", "years")
 
 
 def interval_to_seconds(interval_str):
+    """
+    Parse a time interval specifier of the form "<count><unit>" into the
+    number of seconds contained in the interval.
+
+    NOTE: This is stricter than Graphite's parser, which accepts any string
+          starting with the shortest prefix for a unit.
+    """
     parts = INTERVAL_RE.match(interval_str)
     if parts is None:
         raise TimeParserValueError(
@@ -39,10 +53,24 @@ def interval_to_seconds(interval_str):
 
 
 def parse_absolute_time(time_str):
+    """
+    Parse a Graphite-compatible absolute time specifier into a
+    datetime object.
+
+    NOTE: Currently unimplemented.
+    """
     raise NotImplementedError("Absolute time specifiers not supported.")
 
 
 def parse_time(time_str, now):
+    """
+    Parse a Graphite-compatible absolute or relative time specifier into a
+    datetime object.
+
+    NOTE: This is stricter than Graphite's parser and accepts a narrower
+          variety of formats. Currently, only relative time specifiers are
+          supported.
+    """
     if time_str.startswith("-"):
         interval = interval_to_seconds(time_str[1:])
         return now - timedelta(seconds=interval)

--- a/go_metrics/metrics/tests/test_graphite.py
+++ b/go_metrics/metrics/tests/test_graphite.py
@@ -167,6 +167,14 @@ class TestGraphiteMetrics(TestCase):
             str(err),
             "86400 data points requested, maximum allowed is 10000")
 
+        # "from" can be later than "until".
+        err = yield self.assertFailure(
+            metrics.get(**{'from': 'now', 'until': '-1d', 'interval': '1s'}),
+            BadMetricsQueryError)
+        self.assertEqual(
+            str(err),
+            "86400 data points requested, maximum allowed is 10000")
+
     @inlineCallbacks
     def test_reject_large_request_with_config(self):
         """

--- a/go_metrics/metrics/tests/test_graphite_time_parser.py
+++ b/go_metrics/metrics/tests/test_graphite_time_parser.py
@@ -218,6 +218,8 @@ class TestGraphiteTimeParser(TestCase):
         """
         self.assert_TPVE(parse_time, "", None)
         self.assert_TPVE(parse_time, "blahblah", None)
+        # This is detected as a YYYYMMDD string, but it's invalid.
+        self.assert_TPVE(parse_time, "20150231", None)
 
         # Graphite accepts the following, we don't.
         self.assert_TPVE(parse_time, "2015_02_01", None)

--- a/go_metrics/metrics/tests/test_graphite_time_parser.py
+++ b/go_metrics/metrics/tests/test_graphite_time_parser.py
@@ -143,3 +143,26 @@ class TestGraphiteTimeParser(TestCase):
             parse_time("-1s", now), datetime(2015, 1, 31, 23, 59, 59))
         self.assertEqual(
             parse_time("-2w", now), datetime(2015, 1, 18, 0, 0, 0))
+        self.assertEqual(
+            parse_time("-2w", datetime(2015, 1, 24, 10, 15, 25)),
+            datetime(2015, 1, 10, 10, 15, 25))
+
+    def test_parse_time_special_values(self):
+        """
+        The strings "now", "yesterday", "today", and "tomorrow" return what one
+        might expect.
+        """
+        now1 = datetime(2015, 2, 1, 0, 0, 0)
+        now2 = datetime(2015, 1, 24, 10, 15, 25)
+        self.assertEqual(parse_time("now", now1), now1)
+        self.assertEqual(parse_time("now", now2), now2)
+        self.assertEqual(
+            parse_time("yesterday", now1), datetime(2015, 1, 31, 0, 0, 0))
+        self.assertEqual(
+            parse_time("yesterday", now2), datetime(2015, 1, 23, 10, 15, 25))
+        self.assertEqual(parse_time("today", now1), now1)
+        self.assertEqual(parse_time("today", now2), now2)
+        self.assertEqual(
+            parse_time("tomorrow", now1), datetime(2015, 2, 2, 0, 0, 0))
+        self.assertEqual(
+            parse_time("tomorrow", now2), datetime(2015, 1, 25, 10, 15, 25))

--- a/go_metrics/metrics/tests/test_graphite_time_parser.py
+++ b/go_metrics/metrics/tests/test_graphite_time_parser.py
@@ -1,0 +1,158 @@
+from datetime import datetime
+
+from twisted.trial.unittest import TestCase
+
+from go_metrics.metrics.graphite_time_parser import (
+    TimeParserValueError, interval_to_seconds, parse_time)
+
+
+class TestGraphiteTimeParser(TestCase):
+    """
+    Tests for Graphite-compatible time parsing functions.
+    """
+
+    def assert_TPVE(self, *args, **kw):
+        """
+        Convenience wrapper for asserting TimeParserValueError is raised.
+        """
+        return self.assertRaises(TimeParserValueError, *args, **kw)
+
+    def test_interval_to_seconds_with_invalid_value(self):
+        """
+        A TimeParserValueError is raised for various invalid values.
+        """
+        self.assert_TPVE(interval_to_seconds, "")
+        self.assert_TPVE(interval_to_seconds, "s")
+        self.assert_TPVE(interval_to_seconds, "1")
+        self.assert_TPVE(interval_to_seconds, "three days")
+        self.assert_TPVE(interval_to_seconds, "-1h")
+        self.assert_TPVE(interval_to_seconds, "2fortnights")
+
+    def test_interval_to_seconds_with_seconds(self):
+        """
+        With a suffix of "s" or "seconds", the interval is parsed in seconds.
+        """
+        self.assertEqual(interval_to_seconds("0s"), 0)
+        self.assertEqual(interval_to_seconds("0seconds"), 0)
+        self.assertEqual(interval_to_seconds("1s"), 1)
+        self.assertEqual(interval_to_seconds("1seconds"), 1)
+        self.assertEqual(interval_to_seconds("60s"), 60)
+        self.assertEqual(interval_to_seconds("60seconds"), 60)
+        self.assertEqual(interval_to_seconds("1234567s"), 1234567)
+        self.assertEqual(interval_to_seconds("1234567seconds"), 1234567)
+        self.assertEqual(interval_to_seconds("012s"), 12)
+        self.assertEqual(interval_to_seconds("012seconds"), 12)
+
+    def test_interval_to_seconds_with_minutes(self):
+        """
+        With a suffix of "min" or "minutes", the interval is parsed in minutes.
+        """
+        self.assertEqual(interval_to_seconds("0min"), 0)
+        self.assertEqual(interval_to_seconds("0minutes"), 0)
+        self.assertEqual(interval_to_seconds("1min"), 60)
+        self.assertEqual(interval_to_seconds("1minutes"), 60)
+        self.assertEqual(interval_to_seconds("60min"), 3600)
+        self.assertEqual(interval_to_seconds("60minutes"), 3600)
+        self.assertEqual(interval_to_seconds("1234567min"), 1234567 * 60)
+        self.assertEqual(interval_to_seconds("1234567minutes"), 1234567 * 60)
+        self.assertEqual(interval_to_seconds("012min"), 720)
+        self.assertEqual(interval_to_seconds("012minutes"), 720)
+
+    def test_interval_to_seconds_with_hours(self):
+        """
+        With a suffix of "h" or "hours", the interval is parsed in hours.
+        """
+        self.assertEqual(interval_to_seconds("0h"), 0)
+        self.assertEqual(interval_to_seconds("0hours"), 0)
+        self.assertEqual(interval_to_seconds("1h"), 3600)
+        self.assertEqual(interval_to_seconds("1hours"), 3600)
+        self.assertEqual(interval_to_seconds("24h"), 24 * 3600)
+        self.assertEqual(interval_to_seconds("24hours"), 24 * 3600)
+        self.assertEqual(interval_to_seconds("1234h"), 1234 * 3600)
+        self.assertEqual(interval_to_seconds("1234hours"), 1234 * 3600)
+        self.assertEqual(interval_to_seconds("012h"), 12 * 3600)
+        self.assertEqual(interval_to_seconds("012hours"), 12 * 3600)
+
+    def test_interval_to_seconds_with_days(self):
+        """
+        With a suffix of "d" or "days", the interval is parsed in days.
+        """
+        self.assertEqual(interval_to_seconds("0d"), 0)
+        self.assertEqual(interval_to_seconds("0days"), 0)
+        self.assertEqual(interval_to_seconds("1d"), 86400)
+        self.assertEqual(interval_to_seconds("1days"), 86400)
+        self.assertEqual(interval_to_seconds("60d"), 60 * 86400)
+        self.assertEqual(interval_to_seconds("60days"), 60 * 86400)
+        self.assertEqual(interval_to_seconds("1234d"), 1234 * 86400)
+        self.assertEqual(interval_to_seconds("1234d"), 1234 * 86400)
+        self.assertEqual(interval_to_seconds("014d"), 14 * 86400)
+        self.assertEqual(interval_to_seconds("014days"), 14 * 86400)
+
+    def test_interval_to_seconds_with_weeks(self):
+        """
+        With a suffix of "w" or "weeks", the interval is parsed in weeks.
+        """
+        self.assertEqual(interval_to_seconds("0w"), 0)
+        self.assertEqual(interval_to_seconds("0weeks"), 0)
+        self.assertEqual(interval_to_seconds("1w"), 604800)
+        self.assertEqual(interval_to_seconds("1weeks"), 604800)
+        self.assertEqual(interval_to_seconds("4w"), 2419200)
+        self.assertEqual(interval_to_seconds("4weeks"), 2419200)
+        self.assertEqual(interval_to_seconds("123w"), 123 * 604800)
+        self.assertEqual(interval_to_seconds("123weeks"), 123 * 604800)
+        self.assertEqual(interval_to_seconds("012w"), 12 * 604800)
+        self.assertEqual(interval_to_seconds("012weeks"), 12 * 604800)
+
+    def test_interval_to_seconds_with_months(self):
+        """
+        With a suffix of "mon" or "months", the interval is parsed in months.
+        """
+        self.assertEqual(interval_to_seconds("0mon"), 0)
+        self.assertEqual(interval_to_seconds("0months"), 0)
+        self.assertEqual(interval_to_seconds("1mon"), 2592000)
+        self.assertEqual(interval_to_seconds("1months"), 2592000)
+        self.assertEqual(interval_to_seconds("12mon"), 12 * 2592000)
+        self.assertEqual(interval_to_seconds("12months"), 12 * 2592000)
+        self.assertEqual(interval_to_seconds("123mon"), 123 * 2592000)
+        self.assertEqual(interval_to_seconds("123months"), 123 * 2592000)
+        self.assertEqual(interval_to_seconds("012mon"), 12 * 2592000)
+        self.assertEqual(interval_to_seconds("012months"), 12 * 2592000)
+
+    def test_interval_to_seconds_with_years(self):
+        """
+        With a suffix of "y" or "years", the interval is parsed in years.
+        """
+        self.assertEqual(interval_to_seconds("0y"), 0)
+        self.assertEqual(interval_to_seconds("0years"), 0)
+        self.assertEqual(interval_to_seconds("1y"), 31536000)
+        self.assertEqual(interval_to_seconds("1years"), 31536000)
+        self.assertEqual(interval_to_seconds("5y"), 5 * 31536000)
+        self.assertEqual(interval_to_seconds("5years"), 5 * 31536000)
+        self.assertEqual(interval_to_seconds("123y"), 123 * 31536000)
+        self.assertEqual(interval_to_seconds("123years"), 123 * 31536000)
+        self.assertEqual(interval_to_seconds("02y"), 2 * 31536000)
+        self.assertEqual(interval_to_seconds("02years"), 2 * 31536000)
+
+    def test_parse_time_with_invalid_interval(self):
+        """
+        If given a time_str starting with "-" and containing an invalid
+        interval, a TimeParserValueError is raised.
+        """
+        now = datetime(2015, 2, 1, 0, 0, 0)
+        self.assert_TPVE(parse_time, "-0", now)
+        self.assert_TPVE(parse_time, "-12", now)
+        self.assert_TPVE(parse_time, "-20150101", now)
+
+    def test_parse_time_with_interval(self):
+        """
+        If given a time_str starting with "-", the time is parsed as an
+        interval prior to "now".
+        """
+        now = datetime(2015, 2, 1, 0, 0, 0)
+        self.assertEqual(parse_time("-0s", now), now)
+        self.assertEqual(
+            parse_time("-1s", now), datetime(2015, 1, 31, 23, 59, 59))
+        self.assertEqual(
+            parse_time("-1s", now), datetime(2015, 1, 31, 23, 59, 59))
+        self.assertEqual(
+            parse_time("-2w", now), datetime(2015, 1, 18, 0, 0, 0))

--- a/go_metrics/metrics/tests/test_graphite_time_parser.py
+++ b/go_metrics/metrics/tests/test_graphite_time_parser.py
@@ -17,6 +17,14 @@ class TestGraphiteTimeParser(TestCase):
         """
         return self.assertRaises(TimeParserValueError, *args, **kw)
 
+    def assert_interval_to_seconds(self, expected, *inputs):
+        """
+        Convenience wrapper for testing multiple equivalent interval strings at
+        once.
+        """
+        for value in inputs:
+            self.assertEqual(interval_to_seconds(value), expected)
+
     def test_interval_to_seconds_with_invalid_value(self):
         """
         A TimeParserValueError is raised for various invalid values.
@@ -32,106 +40,85 @@ class TestGraphiteTimeParser(TestCase):
         """
         With a suffix of "s" or "seconds", the interval is parsed in seconds.
         """
-        self.assertEqual(interval_to_seconds("0s"), 0)
-        self.assertEqual(interval_to_seconds("0seconds"), 0)
-        self.assertEqual(interval_to_seconds("1s"), 1)
-        self.assertEqual(interval_to_seconds("1seconds"), 1)
-        self.assertEqual(interval_to_seconds("60s"), 60)
-        self.assertEqual(interval_to_seconds("60seconds"), 60)
-        self.assertEqual(interval_to_seconds("1234567s"), 1234567)
-        self.assertEqual(interval_to_seconds("1234567seconds"), 1234567)
-        self.assertEqual(interval_to_seconds("012s"), 12)
-        self.assertEqual(interval_to_seconds("012seconds"), 12)
+        self.assert_interval_to_seconds(0, "0s", "0second", "0seconds")
+        self.assert_interval_to_seconds(1, "1s", "1second", "1seconds")
+        self.assert_interval_to_seconds(60, "60s", "60second", "60seconds")
+        self.assert_interval_to_seconds(
+            1234567, "1234567s", "1234567second", "1234567seconds")
+        self.assert_interval_to_seconds(12, "012s", "012second", "012seconds")
 
     def test_interval_to_seconds_with_minutes(self):
         """
         With a suffix of "min" or "minutes", the interval is parsed in minutes.
         """
-        self.assertEqual(interval_to_seconds("0min"), 0)
-        self.assertEqual(interval_to_seconds("0minutes"), 0)
-        self.assertEqual(interval_to_seconds("1min"), 60)
-        self.assertEqual(interval_to_seconds("1minutes"), 60)
-        self.assertEqual(interval_to_seconds("60min"), 3600)
-        self.assertEqual(interval_to_seconds("60minutes"), 3600)
-        self.assertEqual(interval_to_seconds("1234567min"), 1234567 * 60)
-        self.assertEqual(interval_to_seconds("1234567minutes"), 1234567 * 60)
-        self.assertEqual(interval_to_seconds("012min"), 720)
-        self.assertEqual(interval_to_seconds("012minutes"), 720)
+        self.assert_interval_to_seconds(0, "0min", "0minute", "0minutes")
+        self.assert_interval_to_seconds(60, "1min", "1minute", "1minutes")
+        self.assert_interval_to_seconds(3600, "60min", "60minute", "60minutes")
+        self.assert_interval_to_seconds(
+            1234567 * 60, "1234567min", "1234567minute", "1234567minutes")
+        self.assert_interval_to_seconds(
+            720, "012min", "012minute", "012minutes")
 
     def test_interval_to_seconds_with_hours(self):
         """
         With a suffix of "h" or "hours", the interval is parsed in hours.
         """
-        self.assertEqual(interval_to_seconds("0h"), 0)
-        self.assertEqual(interval_to_seconds("0hours"), 0)
-        self.assertEqual(interval_to_seconds("1h"), 3600)
-        self.assertEqual(interval_to_seconds("1hours"), 3600)
-        self.assertEqual(interval_to_seconds("24h"), 24 * 3600)
-        self.assertEqual(interval_to_seconds("24hours"), 24 * 3600)
-        self.assertEqual(interval_to_seconds("1234h"), 1234 * 3600)
-        self.assertEqual(interval_to_seconds("1234hours"), 1234 * 3600)
-        self.assertEqual(interval_to_seconds("012h"), 12 * 3600)
-        self.assertEqual(interval_to_seconds("012hours"), 12 * 3600)
+        self.assert_interval_to_seconds(0, "0h", "0hour", "0hours")
+        self.assert_interval_to_seconds(3600, "1h", "1hour", "1hours")
+        self.assert_interval_to_seconds(24 * 3600, "24h", "24hour", "24hours")
+        self.assert_interval_to_seconds(
+            1234 * 3600, "1234h", "1234hour", "1234hours")
+        self.assert_interval_to_seconds(
+            12 * 3600, "012h", "012hour", "012hours")
 
     def test_interval_to_seconds_with_days(self):
         """
         With a suffix of "d" or "days", the interval is parsed in days.
         """
-        self.assertEqual(interval_to_seconds("0d"), 0)
-        self.assertEqual(interval_to_seconds("0days"), 0)
-        self.assertEqual(interval_to_seconds("1d"), 86400)
-        self.assertEqual(interval_to_seconds("1days"), 86400)
-        self.assertEqual(interval_to_seconds("60d"), 60 * 86400)
-        self.assertEqual(interval_to_seconds("60days"), 60 * 86400)
-        self.assertEqual(interval_to_seconds("1234d"), 1234 * 86400)
-        self.assertEqual(interval_to_seconds("1234d"), 1234 * 86400)
-        self.assertEqual(interval_to_seconds("014d"), 14 * 86400)
-        self.assertEqual(interval_to_seconds("014days"), 14 * 86400)
+        self.assert_interval_to_seconds(0, "0d", "0day", "0days")
+        self.assert_interval_to_seconds(86400, "1d", "1day", "1days")
+        self.assert_interval_to_seconds(60 * 86400, "60d", "60day", "60days")
+        self.assert_interval_to_seconds(
+            1234 * 86400, "1234d", "1234day", "1234days")
+        self.assert_interval_to_seconds(
+            14 * 86400, "014d", "014day", "014days")
 
     def test_interval_to_seconds_with_weeks(self):
         """
         With a suffix of "w" or "weeks", the interval is parsed in weeks.
         """
-        self.assertEqual(interval_to_seconds("0w"), 0)
-        self.assertEqual(interval_to_seconds("0weeks"), 0)
-        self.assertEqual(interval_to_seconds("1w"), 604800)
-        self.assertEqual(interval_to_seconds("1weeks"), 604800)
-        self.assertEqual(interval_to_seconds("4w"), 2419200)
-        self.assertEqual(interval_to_seconds("4weeks"), 2419200)
-        self.assertEqual(interval_to_seconds("123w"), 123 * 604800)
-        self.assertEqual(interval_to_seconds("123weeks"), 123 * 604800)
-        self.assertEqual(interval_to_seconds("012w"), 12 * 604800)
-        self.assertEqual(interval_to_seconds("012weeks"), 12 * 604800)
+        self.assert_interval_to_seconds(0, "0w", "0week", "0weeks")
+        self.assert_interval_to_seconds(604800, "1w", "1week", "1weeks")
+        self.assert_interval_to_seconds(4 * 604800, "4w", "4week", "4weeks")
+        self.assert_interval_to_seconds(
+            123 * 604800, "123w", "123week", "123weeks")
+        self.assert_interval_to_seconds(
+            12 * 604800, "012w", "012week", "012weeks")
 
     def test_interval_to_seconds_with_months(self):
         """
         With a suffix of "mon" or "months", the interval is parsed in months.
         """
-        self.assertEqual(interval_to_seconds("0mon"), 0)
-        self.assertEqual(interval_to_seconds("0months"), 0)
-        self.assertEqual(interval_to_seconds("1mon"), 2592000)
-        self.assertEqual(interval_to_seconds("1months"), 2592000)
-        self.assertEqual(interval_to_seconds("12mon"), 12 * 2592000)
-        self.assertEqual(interval_to_seconds("12months"), 12 * 2592000)
-        self.assertEqual(interval_to_seconds("123mon"), 123 * 2592000)
-        self.assertEqual(interval_to_seconds("123months"), 123 * 2592000)
-        self.assertEqual(interval_to_seconds("012mon"), 12 * 2592000)
-        self.assertEqual(interval_to_seconds("012months"), 12 * 2592000)
+        self.assert_interval_to_seconds(0, "0mon", "0month", "0months")
+        self.assert_interval_to_seconds(2592000, "1mon", "1month", "1months")
+        self.assert_interval_to_seconds(
+            12 * 2592000, "12mon", "12month", "12months")
+        self.assert_interval_to_seconds(
+            123 * 2592000, "123mon", "123month", "123months")
+        self.assert_interval_to_seconds(
+            12 * 2592000, "012mon", "012month", "012months")
 
     def test_interval_to_seconds_with_years(self):
         """
         With a suffix of "y" or "years", the interval is parsed in years.
         """
-        self.assertEqual(interval_to_seconds("0y"), 0)
-        self.assertEqual(interval_to_seconds("0years"), 0)
-        self.assertEqual(interval_to_seconds("1y"), 31536000)
-        self.assertEqual(interval_to_seconds("1years"), 31536000)
-        self.assertEqual(interval_to_seconds("5y"), 5 * 31536000)
-        self.assertEqual(interval_to_seconds("5years"), 5 * 31536000)
-        self.assertEqual(interval_to_seconds("123y"), 123 * 31536000)
-        self.assertEqual(interval_to_seconds("123years"), 123 * 31536000)
-        self.assertEqual(interval_to_seconds("02y"), 2 * 31536000)
-        self.assertEqual(interval_to_seconds("02years"), 2 * 31536000)
+        self.assert_interval_to_seconds(0, "0y", "0year", "0years")
+        self.assert_interval_to_seconds(31536000, "1y", "1year", "1years")
+        self.assert_interval_to_seconds(5 * 31536000, "5y", "5year", "5years")
+        self.assert_interval_to_seconds(
+            123 * 31536000, "123y", "123year", "123years")
+        self.assert_interval_to_seconds(
+            2 * 31536000, "02y", "02year", "02years")
 
     def test_parse_time_with_invalid_interval(self):
         """


### PR DESCRIPTION
It's currently legal to ask for 30 days of data at 1 second granularity, but it makes all sorts of things sad.