### PR TITLE
Strip aggregation name from metrics before firing them.

### DIFF
--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -24,12 +24,12 @@ from go_metrics.metrics.graphite_time_parser import (
     interval_to_seconds, parse_time)
 
 
-
 def strip_aggregator(name, aggregator):
     name = name.split('.')
     if name[-1] == aggregator.name:
         return '.'.join(name[:-1])
     return '.'.join(name)
+
 
 def is_error(resp):
     return 400 <= resp.code <= 599

--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -28,6 +28,12 @@ def agg_from_name(name):
     return name.split('.')[-1]
 
 
+def strip_aggregator(name, aggregator):
+    name = name.split('.')
+    if name[-1] == aggregator.name:
+        return '.'.join(name[:-1])
+    return '.'.join(name)
+
 def is_error(resp):
     return 400 <= resp.code <= 599
 
@@ -166,6 +172,7 @@ class GraphiteMetrics(Metrics):
             metric_name = self._get_full_metric_name(mname)
             aggregator = self.aggregators.get(
                 agg_from_name(metric_name), AVG)
+            metric_name = strip_aggregator(metric_name, aggregator)
 
             try:
                 mvalue = float(mvalue)


### PR DESCRIPTION
Currently `.fire(**kw)` does:
```python
for mname, mvalue in kw.iteritems():
            metric_name = self._get_full_metric_name(mname)
            aggregator = self.aggregators.get(
                agg_from_name(metric_name), AVG)
```
However, Vumi's aggregation worker appends the aggregator name to the end of the metric when it performs aggregation. Thus after determining the aggregator, we need to strip the aggregation suffix from the metric name before firing it (e.g. `foo.last` becomes `foo` with aggregator `LAST`).