### PR TITLE
Tear down graphite backend's metric worker

### DIFF
--- a/go_metrics/metrics/base.py
+++ b/go_metrics/metrics/base.py
@@ -68,6 +68,11 @@ class MetricsBackend(object):
         Optionally override for backend-specific setup
         """
 
+    def teardown(self):
+        """
+        Optionally override for backend-specific tearing down
+        """
+
     def get_model(self, owner_id):
         """
         Creates a new instance of the backend's metric model from the given

--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -299,11 +299,13 @@ class GraphiteBackend(MetricsBackend):
             'vhost': config.amqp_vhost,
             'specfile': config.amqp_spec,
             })
-        self.worker = worker_creator.create_worker_by_class(
-            MetricWorker, {
-                'prefix': config.prefix
-            })
+
+        self.worker = self.create_worker()
         self.worker.startService()
+
+    def create_worker(self):
+        return worker_creator.create_worker_by_class(
+            MetricWorker, {'prefix': config.prefix})
 
     @inlineCallbacks
     def teardown(self):

--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -16,8 +16,8 @@ import treq
 from confmodel.errors import ConfigError
 from confmodel.fields import ConfigText, ConfigBool, ConfigInt
 
-from vumi.blinkenlights.metrics import Metric, SUM, AVG, MAX, MIN, LAST
-from vumi.blinkenlights.metrics import MetricManager as BaseMetricManager
+from vumi.blinkenlights.metrics import (
+    Metric, MetricManager, SUM, AVG, MAX, MIN, LAST)
 from vumi.service import Worker, WorkerCreator
 
 from go_metrics.metrics.base import (
@@ -198,15 +198,6 @@ class GraphiteMetrics(Metrics):
         [mm.oneshot(metric, value) for metric, value in metrics]
 
         returnValue(metrics_values)
-
-
-class MetricManager(BaseMetricManager):
-    def start_polling(self):
-        # TODO remove once base metric manager works this way
-        self._task = LoopingCall(self.publish_metrics)
-        self._task_d = self._task.start(self._publish_interval, now=False)
-        self._task_d.addErrback(
-            lambda f: log.err(f, "MetricManager polling task died"))
 
 
 class MetricWorker(Worker):

--- a/go_metrics/metrics/tests/test_graphite.py
+++ b/go_metrics/metrics/tests/test_graphite.py
@@ -543,12 +543,10 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        print 1111
         backend = yield self.mk_backend(
             graphite_url=graphite.url,
             username="root",
             password="toor")
-        print 222
 
         metrics = GraphiteMetrics(backend, 'owner-1')
 

--- a/go_metrics/metrics/tests/test_graphite.py
+++ b/go_metrics/metrics/tests/test_graphite.py
@@ -25,13 +25,10 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
         self.addCleanup(graphite.stop)
         returnValue(graphite)
 
-    @inlineCallbacks
     def mk_backend(self, **kw):
         kw.setdefault('persistent', False)
         backend = GraphiteBackend(kw)
-        backend.worker = yield self.get_worker({
-            'prefix': backend.config.prefix,
-            }, MetricWorker)
+        self.addCleanup(backend.teardown)
         returnValue(backend)
 
     @inlineCallbacks
@@ -43,7 +40,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(**{
@@ -78,7 +75,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(**{
@@ -110,7 +107,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(**{
@@ -149,7 +146,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             }])
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         data = yield metrics.get(m=['stores.a.b.last', 'stores.b.a.max'])
@@ -180,7 +177,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(**{
@@ -197,7 +194,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
         """
         Requests for excessive amounts of data are rejected.
         """
-        backend = yield self.mk_backend()
+        backend = self.mk_backend()
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         err = yield self.assertFailure(
@@ -228,7 +225,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         # Two metrics, 8640 points each.
@@ -259,7 +256,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(
+        backend = self.mk_backend(
             graphite_url=graphite.url, max_response_size=100000)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
@@ -284,7 +281,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         yield metrics.get(m=['stores.a.b.last'])
@@ -306,7 +303,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return ':('
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         err = yield self.assertFailure(metrics.get(), MetricsBackendError)
@@ -335,7 +332,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             }])
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         self.assertEqual(
@@ -367,7 +364,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             }])
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         data = yield metrics.get(
@@ -431,7 +428,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             }])
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         data = yield metrics.get(
@@ -477,7 +474,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             }])
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         data = yield metrics.get(
@@ -522,7 +519,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
     @inlineCallbacks
     def test_get_null_handling_unrecognised(self):
         graphite = yield self.mk_graphite()
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         err = yield self.assertFailure(
@@ -539,7 +536,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(
+        backend = self.mk_backend(
             graphite_url=graphite.url,
             username="root",
             password="toor")
@@ -567,7 +564,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
             return '{}'
 
         graphite = yield self.mk_graphite(handler)
-        backend = yield self.mk_backend(graphite_url=graphite.url)
+        backend = self.mk_backend(graphite_url=graphite.url)
 
         metrics = GraphiteMetrics(backend, 'owner-1')
 
@@ -583,7 +580,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
 
     @inlineCallbacks
     def test_post_request_single(self):
-        backend = yield self.mk_backend()
+        backend = self.mk_backend()
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         res = yield metrics.fire(**{'foo.avg': 1.7})
@@ -597,7 +594,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
 
     @inlineCallbacks
     def test_post_request_multiple(self):
-        backend = yield self.mk_backend()
+        backend = self.mk_backend()
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         res = yield metrics.fire(**{'foo.avg': 1.2, 'oof.avg': 2.7})
@@ -614,7 +611,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
 
     @inlineCallbacks
     def test_post_request_bad_value(self):
-        backend = yield self.mk_backend()
+        backend = self.mk_backend()
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         try:
@@ -628,7 +625,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
 
     @inlineCallbacks
     def test_post_request_bad_aggregator(self):
-        backend = yield self.mk_backend()
+        backend = self.mk_backend()
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         try:
@@ -641,7 +638,7 @@ class TestGraphiteMetrics(VumiWorkerTestCase):
 
     @inlineCallbacks
     def test_post_aggregators(self):
-        backend = yield self.mk_backend()
+        backend = self.mk_backend()
         metrics = GraphiteMetrics(backend, 'owner-1')
 
         for agg in GraphiteMetrics.aggregators:

--- a/go_metrics/server.py
+++ b/go_metrics/server.py
@@ -1,6 +1,6 @@
 from urlparse import parse_qs as _parse_qs
 
-from twisted.internet.defer import maybeDeferred
+from twisted.internet.defer import maybeDeferred, inlineCallbacks
 
 from confmodel import Config
 from confmodel.fields import ConfigDict
@@ -57,6 +57,10 @@ class MetricsApi(ApiApplication):
     def initialize(self, settings, config):
         config = MetricsApiConfig(config)
         self.backend = self.backend_class(config.backend)
+
+    @inlineCallbacks
+    def teardown(self):
+        yield self.backend.teardown()
 
     def get_metrics_model(self, owner_id):
         return self.backend.get_model(owner_id)


### PR DESCRIPTION
At the moment, we start the metric worker when we initialise the graphite backend, but do not do any teardown later.