### PR TITLE
Add http basic auth

### DIFF
--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -269,7 +269,7 @@ class GraphiteBackendConfig(MetricsBackend.config_class):
 
     password = ConfigText(
         ("Basic auth password for authenticating requests to graphite. "
-         "DEPRECATED, use graphite_username instead."),
+         "DEPRECATED, use graphite_password instead."),
         required=False)
 
     max_response_size = ConfigInt(

--- a/go_metrics/metrics/graphite.py
+++ b/go_metrics/metrics/graphite.py
@@ -13,6 +13,7 @@ import treq
 
 from confmodel.errors import ConfigError
 from confmodel.fields import ConfigText, ConfigBool, ConfigInt
+from confmodel.fallbacks import SingleFieldFallback
 
 from vumi.blinkenlights.metrics import (
     Metric, MetricManager, SUM, AVG, MAX, MIN, LAST)
@@ -245,12 +246,30 @@ class GraphiteBackendConfig(MetricsBackend.config_class):
          "connection for the requests made to graphite's web app."),
         default=True)
 
-    username = ConfigText(
+    basicauth_username = ConfigText(
+        'Username for Basic Authentication for the Metrics API.',
+        required=False)
+
+    basicauth_password = ConfigText(
+        'Password for Basic Authentication for the Metrics API.',
+        required=False)
+
+    graphite_username = ConfigText(
         "Basic auth username for authenticating requests to graphite.",
+        required=False, fallbacks=[SingleFieldFallback("username")])
+
+    graphite_password = ConfigText(
+        "Basic auth username for authenticating requests to graphite.",
+        required=False, fallbacks=[SingleFieldFallback("password")])
+
+    username = ConfigText(
+        ("Basic auth username for authenticating requests to graphite. "
+         "DEPRECATED, use graphite_username instead."),
         required=False)
 
     password = ConfigText(
-        "Basic auth password for authenticating requests to graphite.",
+        ("Basic auth password for authenticating requests to graphite. "
+         "DEPRECATED, use graphite_username instead."),
         required=False)
 
     max_response_size = ConfigInt(

--- a/go_metrics/server.py
+++ b/go_metrics/server.py
@@ -1,3 +1,6 @@
+import functools
+import base64
+
 from urlparse import parse_qs as _parse_qs
 
 from twisted.internet.defer import maybeDeferred, inlineCallbacks
@@ -6,6 +9,7 @@ from confmodel import Config
 from confmodel.fields import ConfigDict
 
 from go_api.cyclone.handlers import ApiApplication, BaseHandler
+from cyclone.web import HTTPAuthenticationRequired
 
 from go_metrics.metrics.base import MetricsBackendError, BadMetricsQueryError
 from go_metrics.metrics.graphite import GraphiteBackend
@@ -17,7 +21,34 @@ def parse_qs(qs):
         for (k, v) in _parse_qs(qs).iteritems())
 
 
+def HTTPBasic(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        backend = self.model.backend
+        config = backend.config
+        if not (getattr(config, 'basicauth_username', None) and
+                getattr(config, 'basicauth_password', None)):
+            return method(self, *args, **kwargs)
+
+        msg = "Authentication Required"
+        if "Authorization" in self.request.headers:
+            auth_type, data = self.request.headers["Authorization"].split()
+            if auth_type == "Basic":
+                usr, pwd = base64.b64decode(data).split(":", 1)
+                if (usr == config.basicauth_username and
+                        pwd == config.basicauth_password):
+                        self._current_user = usr
+                        return method(self, *args, **kwargs)
+                msg = "Authentication Failed"
+        raise HTTPAuthenticationRequired(
+            log_message=msg, auth_type="Basic", realm="Metrics API")
+
+    return wrapper
+
+
 class MetricsHandler(BaseHandler):
+
+    @HTTPBasic
     def get(self):
         query = parse_qs(self.request.query)
         d = maybeDeferred(self.model.get, **query)
@@ -32,6 +63,7 @@ class MetricsHandler(BaseHandler):
             raise BadMetricsQueryError(
                 "Invalid query %r, should be dict, not %s" % (d, type(d)))
 
+    @HTTPBasic
     def post(self):
         data = self.parse_json(self.request.body)
         d = maybeDeferred(self._assert_dict, data)

--- a/go_metrics/server.py
+++ b/go_metrics/server.py
@@ -32,14 +32,20 @@ def HTTPBasic(method):
 
         msg = "Authentication Required"
         if "Authorization" in self.request.headers:
-            auth_type, data = self.request.headers["Authorization"].split()
-            if auth_type == "Basic":
-                usr, pwd = base64.b64decode(data).split(":", 1)
-                if (usr == config.basicauth_username and
-                        pwd == config.basicauth_password):
-                        self._current_user = usr
-                        return method(self, *args, **kwargs)
-                msg = "Authentication Failed"
+            try:
+                auth_type, data = self.request.headers["Authorization"].split()
+                if auth_type == "Basic":
+                    usr, pwd = base64.b64decode(data).split(":", 1)
+                    if (usr == config.basicauth_username and
+                            pwd == config.basicauth_password):
+                            self._current_user = usr
+                            return method(self, *args, **kwargs)
+                    msg = "Authentication Failed"
+            except (ValueError, TypeError):
+                # NOTE: ValueError for when the split() doesn't work
+                #       TypeError for when the data isn't base64 decodeable
+                msg = "Invalid Authorization header"
+
         raise HTTPAuthenticationRequired(
             log_message=msg, auth_type="Basic", realm="Metrics API")
 

--- a/go_metrics/tests/test_server.py
+++ b/go_metrics/tests/test_server.py
@@ -84,6 +84,34 @@ class TestMetricsApi(TestCase):
             (yield resp.json()),
             {'grault': 'garply'})
 
+        # Test invalid Authorization header
+        resp = yield get('/metrics/', headers={
+            'Authorization': 'Garbage',
+        })
+        self.assertEqual(
+            resp.headers.getRawHeaders('www-authenticate'),
+            ['Basic realm="Metrics API"'])
+        self.assertEqual(
+            (yield resp.json()),
+            {
+                'status_code': 401,
+                'reason': 'Invalid Authorization header'
+            })
+
+        # Test invalid Authorization data
+        resp = yield get('/metrics/', headers={
+            'Authorization': 'Basic 1',
+        })
+        self.assertEqual(
+            resp.headers.getRawHeaders('www-authenticate'),
+            ['Basic realm="Metrics API"'])
+        self.assertEqual(
+            (yield resp.json()),
+            {
+                'status_code': 401,
+                'reason': 'Invalid Authorization header'
+            })
+
     def test_initialize_backend(self):
         class ToyBackendConfig(DummyBackend.config_class):
             foo = ConfigText("A foo")


### PR DESCRIPTION
This deprecates the old `username` and `password` config fields and replaces them with `graphite_username` and `graphite_password`. This is a backwards compatible change as the old values of `username` and `password` are read when `graphite_username` and `graphite_password` are not set.

It adds `basicauth_username` and `basicauth_password` which, when set, enforces HTTP Basic Authentication for both HTTP GET and POST requests.
